### PR TITLE
Checking the double call to the system function in method MIns…

### DIFF
--- a/minstall.cpp
+++ b/minstall.cpp
@@ -131,9 +131,8 @@ QString MInstall::getCmdOut(QString cmd)
     if (fp == NULL) {
         return QString (ret);
     }
-    int i;
     if (fgets(line, sizeof line, fp) != NULL) {
-        i = strlen(line);
+        int i = strlen(line);
         line[--i] = '\0';
         ret = line;
     }
@@ -506,9 +505,10 @@ bool MInstall::makeLinuxPartition(QString dev, const char *type, bool bad, QStri
             if (strncmp(type, "ext*", 4) == 0) {
                 // ext4 tuning
                 cmd = QString("/sbin/tune2fs -c0 -C0 -i1m %1").arg(dev);
-            }
-            if (system(cmd.toUtf8()) != 0) {
-                // error
+                if (system(cmd.toUtf8()) != 0) {
+                    // error
+                    return false;
+                }
             }
         }
         return true;


### PR DESCRIPTION
I Checked the end of the [`MInstall::makeLinuxPartition`](https://github.com/fitorec/antix-installer/blob/master/minstall.cpp#L388) function and apparently on line `500` it is executed and it is checked that it is executed correctly, later if the partition matches with `ext *`, the command is modified and in my opinion that is when the command should be executed again. In the rest of the times we only execute the same command twice.

I tried to review the logic of this function a bit and the nesting level confused me a bit, on the other hand there are comparisons that apparently will never be fulfilled, for example:

```c++
if (strncmp(type, "xfs", 4) == 0) {
  // never run
}
if (strncmp(type, "jfs", 4) == 0) {
  // never run
}
```
I would like to refactor this function, adding some unified test, roughly I think we could eliminate said nesting and at the same time review the string comparisons with something like:

```c++
if (strncmp(type, "reiser4", 7) == 0) {
    // ..
} else if(strncmp(type, "ext3", 4) == 0) {
    // ..
} else if(strncmp(type, "ext2", 4) == 0) {
    // ..
} else if(strncmp(type, "btrfs", 5) == 0) {
    // ..
} else if(strncmp(type, "xfs", 3) == 0) {
    // ..
} else if(strncmp(type, "jfs", 3) == 0) {
    // ..
}
if (system(cmd.toUtf8()) == 0) {
    return true;
}
// error
return false;
```